### PR TITLE
Fix Perl POD commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules/*
 *.pm.tdy
 *.bs
 .idea/
+logs/standalone_results.log

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ node_modules/*
 *.pm.tdy
 *.bs
 .idea/
-logs/standalone_results.log

--- a/lib/RenderApp/Controller/FormatRenderedProblem.pm
+++ b/lib/RenderApp/Controller/FormatRenderedProblem.pm
@@ -17,7 +17,9 @@
 ################################################################################
 
 =head1 NAME
+
 FormatRenderedProblem.pm
+
 =cut
 
 package RenderApp::Controller::FormatRenderedProblem;

--- a/lib/WeBWorK/lib/WWSafe.pm
+++ b/lib/WeBWorK/lib/WWSafe.pm
@@ -301,32 +301,45 @@ sub rdo {
 1;
 
 __END__
+
 =head1 NAME
+
 Safe - Compile and execute code in restricted compartments
+
 =head1 SYNOPSIS
+
   use WWSafe;
   $compartment = new Safe;
   $compartment->permit(qw(time sort :browse));
   $result = $compartment->reval($unsafe_code);
+
 =head1 DESCRIPTION
+
 The Safe extension module allows the creation of compartments
 in which perl code can be evaluated. Each compartment has
+
 =over 8
+
 =item a new namespace
+
 The "root" of the namespace (i.e. "main::") is changed to a
 different package and code evaluated in the compartment cannot
 refer to variables outside this namespace, even with run-time
 glob lookups and other tricks.
+
 Code which is compiled outside the compartment can choose to place
 variables into (or I<share> variables with) the compartment's namespace
 and only that data will be visible to code evaluated in the
 compartment.
+
 By default, the only variables shared with compartments are the
 "underscore" variables $_ and @_ (and, technically, the less frequently
 used %_, the _ filehandle and so on). This is because otherwise perl
 operators which default to $_ will not work and neither will the
 assignment of arguments to @_ on subroutine entry.
+
 =item an operator mask
+
 Each compartment has an associated "operator mask". Recall that
 perl code is compiled into an internal format before execution.
 Evaluating perl code (e.g. via "eval" or "do 'file'") causes
@@ -336,127 +349,180 @@ Code evaluated in a compartment compiles subject to the
 compartment's operator mask. Attempting to evaluate code in a
 compartment which contains a masked operator will cause the
 compilation to fail with an error. The code will not be executed.
+
 The default operator mask for a newly created compartment is
 the ':default' optag.
+
 It is important that you read the L<Opcode> module documentation
 for more information, especially for detailed definitions of opnames,
 optags and opsets.
+
 Since it is only at the compilation stage that the operator mask
 applies, controlled access to potentially unsafe operations can
 be achieved by having a handle to a wrapper subroutine (written
 outside the compartment) placed into the compartment. For example,
+
     $cpt = new Safe;
     sub wrapper {
         # vet arguments and perform potentially unsafe operations
     }
     $cpt->share('&wrapper');
+
 =back
+
 =head1 WARNING
+
 The authors make B<no warranty>, implied or otherwise, about the
 suitability of this software for safety or security purposes.
+
 The authors shall not in any case be liable for special, incidental,
 consequential, indirect or other similar damages arising from the use
 of this software.
+
 Your mileage will vary. If in any doubt B<do not use it>.
+
 =head2 RECENT CHANGES
+
 The interface to the Safe module has changed quite dramatically since
 version 1 (as supplied with Perl5.002). Study these pages carefully if
 you have code written to use Safe version 1 because you will need to
 makes changes.
+
 =head2 Methods in class Safe
+
 To create a new compartment, use
+
     $cpt = new Safe;
+
 Optional argument is (NAMESPACE), where NAMESPACE is the root namespace
 to use for the compartment (defaults to "Safe::Root0", incremented for
 each new compartment).
+
 Note that version 1.00 of the Safe module supported a second optional
 parameter, MASK.  That functionality has been withdrawn pending deeper
 consideration. Use the permit and deny methods described below.
+
 The following methods can then be used on the compartment
 object returned by the above constructor. The object argument
 is implicit in each case.
+
 =over 8
+
 =item permit (OP, ...)
+
 Permit the listed operators to be used when compiling code in the
 compartment (in I<addition> to any operators already permitted).
+
 You can list opcodes by names, or use a tag name; see
 L<Opcode/"Predefined Opcode Tags">.
+
 =item permit_only (OP, ...)
+
 Permit I<only> the listed operators to be used when compiling code in
 the compartment (I<no> other operators are permitted).
+
 =item deny (OP, ...)
+
 Deny the listed operators from being used when compiling code in the
 compartment (other operators may still be permitted).
+
 =item deny_only (OP, ...)
+
 Deny I<only> the listed operators from being used when compiling code
 in the compartment (I<all> other operators will be permitted).
+
 =item trap (OP, ...)
+
 =item untrap (OP, ...)
+
 The trap and untrap methods are synonyms for deny and permit
 respectfully.
+
 =item share (NAME, ...)
+
 This shares the variable(s) in the argument list with the compartment.
 This is almost identical to exporting variables using the L<Exporter>
 module.
+
 Each NAME must be the B<name> of a non-lexical variable, typically
 with the leading type identifier included. A bareword is treated as a
 function name.
+
 Examples of legal names are '$foo' for a scalar, '@foo' for an
 array, '%foo' for a hash, '&foo' or 'foo' for a subroutine and '*foo'
 for a glob (i.e.  all symbol table entries associated with "foo",
 including scalar, array, hash, sub and filehandle).
+
 Each NAME is assumed to be in the calling package. See share_from
 for an alternative method (which share uses).
+
 =item share_from (PACKAGE, ARRAYREF)
+
 This method is similar to share() but allows you to explicitly name the
 package that symbols should be shared from. The symbol names (including
 type characters) are supplied as an array reference.
+
     $safe->share_from('main', [ '$foo', '%bar', 'func' ]);
+
 =item varglob (VARNAME)
+
 This returns a glob reference for the symbol table entry of VARNAME in
 the package of the compartment. VARNAME must be the B<name> of a
 variable without any leading type marker. For example,
+
     $cpt = new Safe 'Root';
     $Root::foo = "Hello world";
     # Equivalent version which doesn't need to know $cpt's package name:
     ${$cpt->varglob('foo')} = "Hello world";
+
 =item reval (STRING)
+
 This evaluates STRING as perl code inside the compartment.
+
 The code can only see the compartment's namespace (as returned by the
 B<root> method). The compartment's root package appears to be the
 C<main::> package to the code inside the compartment.
+
 Any attempt by the code in STRING to use an operator which is not permitted
 by the compartment will cause an error (at run-time of the main program
 but at compile-time for the code in STRING).  The error is of the form
 "'%s' trapped by operation mask...".
+
 If an operation is trapped in this way, then the code in STRING will
 not be executed. If such a trapped operation occurs or any other
 compile-time or return error, then $@ is set to the error message, just
 as with an eval().
+
 If there is no error, then the method returns the value of the last
 expression evaluated, or a return statement may be used, just as with
 subroutines and B<eval()>. The context (list or scalar) is determined
 by the caller as usual.
+
 This behaviour differs from the beta distribution of the Safe extension
 where earlier versions of perl made it hard to mimic the return
 behaviour of the eval() command and the context was always scalar.
+
 Some points to note:
+
 If the entereval op is permitted then the code can use eval "..." to
 'hide' code which might use denied ops. This is not a major problem
 since when the code tries to execute the eval it will fail because the
 opmask is still in effect. However this technique would allow clever,
 and possibly harmful, code to 'probe' the boundaries of what is
 possible.
+
 Any string eval which is executed by code executing in a compartment,
 or by code called from code executing in a compartment, will be eval'd
 in the namespace of the compartment. This is potentially a serious
 problem.
+
 Consider a function foo() in package pkg compiled outside a compartment
 but shared with it. Assume the compartment has a root package called
 'Root'. If foo() contains an eval statement like eval '$foo = 1' then,
 normally, $pkg::foo will be set to 1.  If foo() is called from the
 compartment (by whatever means) then instead of setting $pkg::foo, the
 eval will actually set $Root::pkg::foo.
+
 This can easily be demonstrated by using a module, such as the Socket
 module, which uses eval "..." as part of an AUTOLOAD function. You can
 'use' the module outside the compartment and share an (autoloaded)
@@ -466,39 +532,62 @@ from the compartment, then the eval in the Socket module's AUTOLOAD
 function happens in the namespace of the compartment. Any variables
 created or used by the eval'd code are now under the control of
 the code in the compartment.
+
 A similar effect applies to I<all> runtime symbol lookups in code
 called from a compartment but not compiled within it.
+
 =item rdo (FILENAME)
+
 This evaluates the contents of file FILENAME inside the compartment.
 See above documentation on the B<reval> method for further details.
+
 =item root (NAMESPACE)
+
 This method returns the name of the package that is the root of the
 compartment's namespace.
+
 Note that this behaviour differs from version 1.00 of the Safe module
 where the root module could be used to change the namespace. That
 functionality has been withdrawn pending deeper consideration.
+
 =item mask (MASK)
+
 This is a get-or-set method for the compartment's operator mask.
+
 With no MASK argument present, it returns the current operator mask of
 the compartment.
+
 With the MASK argument present, it sets the operator mask for the
 compartment (equivalent to calling the deny_only method).
+
 =back
+
 =head2 Some Safety Issues
+
 This section is currently just an outline of some of the things code in
 a compartment might do (intentionally or unintentionally) which can
 have an effect outside the compartment.
+
 =over 8
+
 =item Memory
+
 Consuming all (or nearly all) available memory.
+
 =item CPU
+
 Causing infinite loops etc.
+
 =item Snooping
+
 Copying private information out of your system. Even something as
 simple as your user name is of value to others. Much useful information
 could be gleaned from your environment variables for example.
+
 =item Signals
+
 Causing signals (especially SIGFPE and SIGALARM) to affect your process.
+
 Setting up a signal handler will need to be carefully considered
 and controlled.  What mask is in effect when a signal handler
 gets called?  If a user can get an imported function to get an
@@ -506,13 +595,21 @@ exception and call the user's signal handler, does that user's
 restricted mask get re-instated before the handler is called?
 Does an imported handler get called with its original mask or
 the user's one?
+
 =item State Changes
+
 Ops such as chdir obviously effect the process as a whole and not just
 the code in the compartment. Ops such as rand and srand have a similar
 but more subtle effect.
+
 =back
+
 =head2 AUTHOR
+
 Originally designed and implemented by Malcolm Beattie.
+
 Reworked to use the Opcode module and other changes added by Tim Bunce.
+
 Currently maintained by the Perl 5 Porters, <perl5-porters@perl.org>.
+
 =cut

--- a/lib/WeBWorK/lib/WeBWorK/Constants.pm
+++ b/lib/WeBWorK/lib/WeBWorK/Constants.pm
@@ -17,7 +17,9 @@
 package WeBWorK::Constants;
 
 =head1 NAME
+
 WeBWorK::Constants - provide constant values for other WeBWorK modules.
+
 =cut
 
 use strict;

--- a/lib/WeBWorK/lib/WeBWorK/CourseEnvironment.pm
+++ b/lib/WeBWorK/lib/WeBWorK/CourseEnvironment.pm
@@ -17,9 +17,12 @@
 package WeBWorK::CourseEnvironment;
 
 =head1 NAME
+
 WeBWorK::CourseEnvironment - Read configuration information from defaults.config
 and course.conf files.
+
 =head1 SYNOPSIS
+
  use WeBWorK::CourseEnvironment;
  $ce = WeBWorK::CourseEnvironment->new({
  	webwork_url         => "/webwork2",
@@ -35,13 +38,16 @@ and course.conf files.
  my $timeout = $courseEnv->{sessionKeyTimeout};
  my $mode    = $courseEnv->{pg}->{options}->{displayMode};
  # etc...
+
 =head1 DESCRIPTION
+
 The WeBWorK::CourseEnvironment module reads the system-wide F<defaults.config> and
 course-specific F<course.conf> files used by WeBWorK to calculate and store
 settings needed throughout the system. The F<.conf> files are perl source files
 that can contain any code allowed under the default safe compartment opset.
 After evaluation of both files, any package variables are copied out of the
 safe compartment into a hash. This hash becomes the course environment.
+
 =cut
 
 use strict;
@@ -53,18 +59,25 @@ use WeBWorK::Debug;
 use Opcode qw(empty_opset);
 
 =head1 CONSTRUCTION
+
 =over
+
 =item new(HASHREF)
+
 HASHREF is a reference to a hash containing scalar variables with which to seed
 the course environment. It must contain at least a value for the key
 C<webworkRoot>.
+
 The C<new> method finds the file F<conf/defaults.config> relative to the given
 C<webwork_dir> directory. After reading this file, it uses the
 C<$courseFiles{environment}> variable, if present, to locate the course
 environment file. If found, the file is read and added to the environment.
+
 =item new(ROOT URLROOT PGROOT COURSENAME)
+
 A deprecated form of the constructor in which four seed variables are given
 explicitly: C<webwork_dir>, C<webwork_url>, C<pg_dir>, and C<courseName>.
+
 =cut
 
 # NEW SYNTAX
@@ -247,24 +260,35 @@ sub new {
 }
 
 =back
+
 =head1 ACCESS
+
 There are no formal accessor methods. However, since the course environemnt is
 a hash of hashes and arrays, is exists as the self hash of an instance
 variable:
+
 	$ce->{someKey}{someOtherKey};
+
 =head1 EXPERIMENTAL ACCESS METHODS
+
 This is an experiment in extending CourseEnvironment to know a little more about
 its contents, and perform useful operations for me.
+
 There is a set of operations that require certain data from the course
 environment. Most of these are un Utils.pm. I've been forced to pass $ce into
 them, so that they can get their data out. But some things are so intrinsically
 linked to the course environment that they might as well be methods in this
 class.
+
 =head2 STATUS METHODS
+
 =over
+
 =item status_abbrev_to_name($status_abbrev)
+
 Given the abbreviation for a status, return the name. Returns undef if the
 abbreviation is not found.
+
 =cut
 
 sub status_abbrev_to_name {
@@ -278,8 +302,10 @@ sub status_abbrev_to_name {
 }
 
 =item status_name_to_abbrevs($status_name)
+
 Returns the list of abbreviations for a given status. Returns an empty list if
 the status is not found.
+
 =cut
 
 sub status_name_to_abbrevs {
@@ -294,7 +320,9 @@ sub status_name_to_abbrevs {
 }
 
 =item status_has_behavior($status_name, $behavior)
+
 Return true if $status_name lists $behavior.
+
 =cut
 
 sub status_has_behavior {
@@ -322,7 +350,9 @@ sub status_has_behavior {
 }
 
 =item status_abbrev_has_behavior($status_abbrev, $behavior)
+
 Return true if the status abbreviated by $status_abbrev lists $behavior.
+
 =cut
 
 sub status_abbrev_has_behavior {
@@ -345,6 +375,7 @@ sub status_abbrev_has_behavior {
 }
 
 =back
+
 =cut
 
 1;

--- a/lib/WeBWorK/lib/WeBWorK/Debug.pm
+++ b/lib/WeBWorK/lib/WeBWorK/Debug.pm
@@ -20,8 +20,11 @@ use Date::Format;
 our @EXPORT = qw(debug);
 
 =head1 NAME
+
 WeBWorK::Debug - Print (or don't print) debugging output.
+
 head1 SYNOPSIS
+
  use WeBWorK::Debug;
 
  # Enable debugging
@@ -32,6 +35,7 @@ head1 SYNOPSIS
 
  # log some debugging output
  debug("Generated 5 widgets.");
+
 =cut
 
 use strict;
@@ -43,42 +47,57 @@ use WeBWorK::Utils qw/undefstr/;
 ################################################################################
 
 =head1 CONFIGURATION VARIABLES
+
 =over
+
 =item $Enabled
+
 If true, debugging messages will be output. If false, they will be ignored.
+
 =cut
 
 our $Enabled = 0 unless defined $Enabled;
 
 =item $Logfile
+
 If non-empty, debugging output will be sent to the file named rather than STDERR.
+
 =cut
 
 our $Logfile = "" unless defined $Logfile;
 
 =item $DenySubroutineOutput
+
 If defined, prevent subroutines matching the following regular expression from
 logging.
+
 =cut
 
 our $DenySubroutineOutput;
 
 =item $AllowSubroutineOutput
+
 If defined, allow only subroutines matching the following regular expression to
 log.
+
 =cut
 
 our $AllowSubroutineOutput;
 
 =back
+
 =cut
 
 ################################################################################
 
 =head1 FUNCTIONS
+
 =over
+
 =item debug(@messages)
+
 Write @messages to the debugging log.
+
 =cut
 
 sub debug {
@@ -113,12 +132,15 @@ sub debug {
 }
 
 =back
+
 =cut
 
 ################################################################################
 
 =head1 AUTHOR
+
 Written by Sam Hathaway, sh002i (at) math.rochester.edu.
+
 =cut
 
 1;

--- a/lib/WeBWorK/lib/WeBWorK/PG.pm
+++ b/lib/WeBWorK/lib/WeBWorK/PG.pm
@@ -17,8 +17,10 @@
 package WeBWorK::PG;
 
 =head1 NAME
+
 WeBWorK::PG - Invoke one of several PG rendering methods using an easy-to-use
 API.
+
 =cut
 
 use strict;
@@ -335,7 +337,9 @@ sub nullSafetyFilter {
 1;
 
 __END__
+
 =head1 SYNOPSIS
+
  $pg = WeBWorK::PG->new(
 	 $ce,         # a WeBWorK::CourseEnvironment object
 	 $user,       # a WeBWorK::DB::Record::User object
@@ -362,90 +366,162 @@ __END__
  $errors     = $pg->{errors};     # text string
  $warnings   = $pg->{warnings};   # text string
  $flags      = $pg->{flags};      # hash reference
+
 =head1 DESCRIPTION
+
 WeBWorK::PG is a factory for modules which use the WeBWorK::PG API. Notable
 modules which use this API (and exist) are WeBWorK::PG::Local and
 WeBWorK::PG::Remote. The course environment key $pg{renderer} is consulted to
 determine which render to use.
+
 =head1 THE WEBWORK::PG API
+
 Modules which support this API must implement the following method:
+
 =over
+
 =item new ENVIRONMENT, USER, KEY, SET, PROBLEM, PSVN, FIELDS, OPTIONS
+
 The C<new> method creates a translator, initializes it using the parameters
 specified, translates a PG file, and processes answers. It returns a reference
 to a blessed hash containing the results of the translation process.
+
 =back
+
 =head2 Parameters
+
 =over
+
 =item ENVIRONMENT
+
 a WeBWorK::CourseEnvironment object
+
 =item USER
+
 a WeBWorK::User object
+
 =item KEY
+
 the session key of the current session
+
 =item SET
+
 a WeBWorK::Set object
+
 =item PROBLEM
+
 a WeBWorK::DB::Record::UserProblem object. The contents of the source_file
 field can specify a PG file either by absolute path or path relative to the
 "templates" directory. I<The caller should remove taint from this value before
 passing!>
+
 =item PSVN
+
 the problem set version number: use variable $psvn
+
 =item FIELDS
+
 a reference to a hash (as returned by &WeBWorK::Form::Vars) containing form
 fields submitted by a problem processor. The translator will look for fields
 like "AnSwEr[0-9]" containing submitted student answers.
+
 =item OPTIONS
+
 a reference to a hash containing the following data:
+
 =over
+
 =item displayMode
+
 one of "plainText", "formattedText", "MathJax" or "images"
+
 =item showHints
+
 boolean, render hints
+
 =item showSolutions
+
 boolean, render solutions
+
 =item refreshMath2img
+
 boolean, force images created by math2img (in "images" mode) to be recreated,
 even if the PG source has not been updated. FIXME: remove this option.
+
 =item processAnswers
+
 boolean, call answer evaluators and graders
+
 =back
+
 =back
+
 =head2 RETURN VALUE
+
 The C<new> method returns a blessed hash reference containing the following
 fields. More information can be found in the documentation for
 WeBWorK::PG::Translator.
+
 =over
+
 =item translator
+
 The WeBWorK::PG::Translator object used to render the problem.
+
 =item head_text
+
 HTML code for the E<lt>headE<gt> block of an resulting web page. Used for
 JavaScript features.
+
 =item body_text
+
 HTML code for the E<lt>bodyE<gt> block of an resulting web page.
+
 =item answers
+
 An C<AnswerHash> object containing submitted answers, and results of answer
 evaluation.
+
 =item result
+
 A hash containing the results of grading the problem.
+
 =item state
+
 A hash containing the new problem state.
+
 =item errors
+
 A string containing any errors encountered while rendering the problem.
+
 =item warnings
+
 A string containing any warnings encountered while rendering the problem.
+
 =item flags
+
 A hash containing PG_flags (see the Translator docs).
+
 =back
+
 =head1 METHODS PROVIDED BY THE BASE CLASS
+
 The following methods are provided for use by subclasses of WeBWorK::PG.
+
 =over
+
 =item defineProblemEnvir ENVIRONMENT, USER, KEY, SET, PROBLEM, PSVN, FIELDS, OPTIONS
+
 Generate a problem environment hash to pass to the renderer.
+
 =item translateDisplayModeNames NAME
+
 NAME contains
+
 =back
+
 =head1 AUTHOR
+
 Written by Sam Hathaway, sh002i (at) math.rochester.edu.
+
 =cut

--- a/lib/WeBWorK/lib/WeBWorK/PG/Local.pm
+++ b/lib/WeBWorK/lib/WeBWorK/PG/Local.pm
@@ -18,16 +18,21 @@ package WeBWorK::PG::Local;
 use base qw(WeBWorK::PG);
 
 =head1 NAME
+
 WeBWorK::PG::Local - Use the WeBWorK::PG API to invoke a local
 WeBWorK::PG::Translator object.
+
 =head1 DESCRIPTION
+
 WeBWorK::PG::Local encapsulates the PG translation process, making multiple
 calls to WeBWorK::PG::Translator. Much of the flexibility of the Translator is
 hidden, instead making choices that are appropriate for the webwork2
 system
+
 It implements the WeBWorK::PG interface and uses a local
 WeBWorK::PG::Translator to perform problem rendering. See the documentation for
 the WeBWorK::PG module for information about the API.
+
 =cut
 
 use strict;
@@ -478,49 +483,86 @@ EOF
 1;
 
 __END__
+
 =head1 OPERATION
+
 WeBWorK::PG::Local goes through the following operations when constructed:
+
 =over
+
 =item Create a translator
+
 Instantiate a WeBWorK::PG::Translator object.
+
 =item Set the directory hash
+
 Set the translator's directory hash (courseScripts, macros, templates, and temp
 directories) from the course environment.
+
 =item Evaluate PG modules
+
 Using the module list from the course environment (pg->modules), perform a
 "use"-like operation to evaluate modules at runtime.
+
 =item Set the problem environment
+
 Use data from the user, set, and problem, as well as the course
 environemnt and translation options, to set the problem environment. The
 default subroutine, &WeBWorK::PG::defineProblemEnvir, is used.
+
 =item Initialize the translator
+
 Call &WeBWorK::PG::Translator::initialize. What more do you want?
+
 =item Load IO.pl, PG.pl and dangerousMacros.pl
+
 These macros must be loaded without opcode masking, so they are loaded here.
+
 =item Set the opcode mask
+
 Set the opcode mask to the default specified by WeBWorK::PG::Translator.
+
 =item Load the problem source
+
 Give the problem source to the translator.
+
 =item Install a safety filter
+
 The safety filter is used to preprocess student input before evaluation. The
 default safety filter, &WeBWorK::PG::safetyFilter, is used.
+
 =item Translate the problem source
+
 Call &WeBWorK::PG::Translator::translate to render the problem source into the
 format given by the display mode.
+
 =item Process student answers
+
 Use form field inputs to evaluate student answers.
+
 =item Load the problem state
+
 Use values from the database to initialize the problem state, so that the
 grader will have a point of reference.
+
 =item Determine an entry order
+
 Use the ANSWER_ENTRY_ORDER flag to determine the order of answers in the
 problem. This is important for problems with dependancies among parts.
+
 =item Install a grader
+
 Use the PROBLEM_GRADER_TO_USE flag, or a default from the course environment,
 to install a grader.
+
 =item Grade the problem
+
 Use the selected grader to grade the problem.
+
 =back
+
 =head1 AUTHOR
+
 Written by Sam Hathaway, sh002i (at) math.rochester.edu.
+
 =cut

--- a/lib/WeBWorK/lib/WeBWorK/Utils/AttemptsTable.pm
+++ b/lib/WeBWorK/lib/WeBWorK/Utils/AttemptsTable.pm
@@ -18,8 +18,11 @@ use 5.010;
 ################################################################################
 
 =head1 NAME
+
 	AttemptsTable
+
 =head1 SYNPOSIS
+
 	my $tbl = WeBWorK::Utils::AttemptsTable->new(
 		$answers,
 		answersSubmitted       => 1,
@@ -43,9 +46,12 @@ use 5.010;
 	$self->{incorrect_ids} = $tbl->incorrect_ids;
 
 =head1 DESCRIPTION
+
 This module handles the formatting of the table which presents the results of analyzing a student's
 answer to a WeBWorK problem.  It is used in Problem.pm, OpaqueServer.pm, standAlonePGproblemRender
+
 =head2 new
+
 	my $tbl = WeBWorK::Utils::AttemptsTable->new(
 		$answers,
 		answersSubmitted       => 1,
@@ -88,20 +94,30 @@ answer to a WeBWorK problem.  It is used in Problem.pm, OpaqueServer.pm, standAl
 
 
 =head2 Methods
+
 =over 4
+
 =item answerTemplate
+
 Returns HTML which formats the analysis of the student's answers to the problem.
+
 =back
+
 =head2 Read/Write Properties
+
 =over 4
+
 =item correct_ids, incorrect_ids,
+
 These are references to lists of the ids of the correct answers and the incorrect answers respectively.
+
 =item showMessages,
 
 This can be switched on or off before exporting the answerTemplate, perhaps under instructions
 	from the PG problem.
 
 =item summary
+
 The contents of the summary can be defined when the attemptsTable object is created.
 The summary can be defined by the PG problem grader
 usually returned as $pg->{result}->{summary}.
@@ -114,6 +130,7 @@ of the default summaries are created:
 	"At least one of the answers above is NOT [fully] correct.',
 
 =back
+
 =cut
 
 package WeBWorK::Utils::AttemptsTable;

--- a/lib/WeBWorK/lib/WeBWorK/Utils/RestrictedClosureClass.pm
+++ b/lib/WeBWorK/lib/WeBWorK/Utils/RestrictedClosureClass.pm
@@ -17,9 +17,12 @@
 package WeBWorK::Utils::RestrictedClosureClass;
 
 =head1 NAME
+
 WeBWorK::Utils::RestrictedClosureClass - Protect instance data and only allow
 calling of specified methods.
+
 =head1 SYNPOSIS
+
  package MyScaryClass;
 
  sub new { return bless { @_[1..$#_] }, ref $_[0] || $_[0] }
@@ -47,24 +50,38 @@ calling of specified methods.
  $locked->call_for_help;               # OK
  print $locked->{secret_data};         # NG (not a hash reference)
  $locked->{secret_data} = "WySiWyG";   # NG (not a hash reference)
+
 =head1 DESCRIPTION
+
 RestrictedClosureClass generates a wrapper object for a given object that
 prevents access to the objects instance data and only allows specified method
 calls. The wrapper object is a closure that calls methods of the underlying
 object, if permitted.
+
 This is great for exposing a limited API to an untrusted environment, i.e. the
 PG Safe compartment.
+
 =head1 CONSTRUCTOR
+
 =over
+
 =item $wrapper_object = CLASS->new($object, @methods)
+
 Generate a wrapper object for the given $object. Only calls to the methods
 listed in @methods will be permitted.
+
 =back
+
 =head1 LIMITATIONS
+
 You can't call SUPER methods, or methods with an explicit class given:
+
  $locked->SUPER::call_for_help         # NG, would be superclass of RestrictedClosureClass
+
 =head1 SEE ALSO
+
 L<perltoot/Closures-as-Objects>
+
 =cut
 
 use strict;


### PR DESCRIPTION
In some cases the lack of these empty lines will cause POD generation errors, and in other cases it just messes up the formatting of the generated POD.

Also, remove logs/standalone_results.log from git.  A .gitkeep file is added to ensure that the logs directory exists.  The renderer creates the log file as needed already.