### PR TITLE
Add support for including a Strict-Transport-Security header (for use only when a proxy or load balancer is handling TLS/SSL) (was PR # 85 for drdrew42 repo)

### DIFF
--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -58,6 +58,16 @@ sub startup {
 	$ENV{baseURL} = $ENV{SITE_HOST} . $ENV{baseURL} unless ( $ENV{baseURL} =~ m|^https?://| );
 	$ENV{formURL} = $ENV{baseURL} . $ENV{formURL} unless ( $ENV{formURL} =~ m|^https?://| );
 
+	# Handle optional Strict-Transport-Security header
+	if (my $HSTS_HEADER = $self->config('HSTS_HEADER')) {
+		$self->hook(before_dispatch => sub {
+			my $c = shift;
+			$c->res->headers->header(
+				'Strict-Transport-Security' => $HSTS_HEADER
+			       );
+		});
+	}
+
 	# Handle optional CORS settings
 	if (my $CORS_ORIGIN = $self->config('CORS_ORIGIN')) {
 		die "CORS_ORIGIN ($CORS_ORIGIN) must be an absolute URL or '*'" 


### PR DESCRIPTION
Same as https://github.com/drdrew42/renderer/pull/85

---

Add support for including a `Strict-Transport-Security` header.

This header is meant to force browsers to only contact site via TLS/SSL ("https"). Using this header is a commonly recommended security practice, but is dangerous should the site have any need to work over plain (port 80) HTTP.

The value for the header is provided in `render.conf` as a string value called `HSTS_HEADER`, and when that value is not provided (or is `false` for Perl purposes) no `Strict-Transport-Security` header will be set.

No default value is being provided in `render.conf.dist` so the header will not be enabled by accident.

The header should only be used on a server which is available via a proxy or load balancer which has a valid SSL certificate and handles the TLS/SSL level (and which will continue to do so for the long-term).

Note: It could be that some proxy setups could add the header at the proxy, but the AWS Elastic Application Load Balancer does not have the option to add this header, but can provide SSL termination, so the header needs to be added on the "back end" (in our case the Standalone renderer).