### PR TITLE
Docker updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-.git
 .gitignore
 **/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.DS_Store
 render_app.conf
+docker-compose.yml
 lib/WeBWorK/htdocs/tmp/renderer/gif/*
 lib/WeBWorK/htdocs/tmp/renderer/images/*
 lib/WeBWorK/htdocs/DATA/*.json

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -1,5 +1,4 @@
 FROM ubuntu:20.04
-LABEL org.opencontainers.image.source=https://github.com/drdrew42/renderer
 MAINTAINER drdrew42
 
 WORKDIR /usr/app
@@ -52,12 +51,3 @@ RUN apt-get update \
 RUN cpanm install Mojo::Base Statistics::R::IO::Rserve Date::Format Future::AsyncAwait Crypt::JWT IO::Socket::SSL CGI::Cookie \
     && rm -fr ./cpanm /root/.cpanm /tmp/*
 
-COPY . .
-
-RUN cd lib/PG/htdocs && npm install && cd ../../.. && npm install
-
-EXPOSE 3000
-
-HEALTHCHECK CMD curl -I localhost:3000/health
-
-CMD hypnotoad -f ./script/render_app

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -1,0 +1,18 @@
+FROM renderer-base:latest
+LABEL org.opencontainers.image.source=https://github.com/drdrew42/renderer
+MAINTAINER drdrew42
+
+WORKDIR /usr/app
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/New_York
+
+
+COPY . .
+
+RUN cd lib/PG/htdocs && npm install && cd ../../.. && npm install
+
+EXPOSE 3000
+
+HEALTHCHECK CMD curl -I localhost:3000/health
+
+CMD hypnotoad -f ./script/render_app

--- a/Dockerfile_with_OPL
+++ b/Dockerfile_with_OPL
@@ -43,6 +43,9 @@ RUN apt-get update \
     libmath-random-secure-perl \
     libdata-structure-util-perl \
     liblocale-maketext-lexicon-perl \
+    libyaml-libyaml-perl \
+    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+    && apt-get install -y --no-install-recommends --no-install-suggests nodejs \
     && apt-get clean \
     && rm -fr /var/lib/apt/lists/* /tmp/*
 
@@ -62,9 +65,7 @@ RUN rm -r webwork-open-problem-library-master/
 
 COPY . .
 
-RUN cp render_app.conf.dist render_app.conf
-
-RUN cd lib/WeBWorK/htdocs && npm install && cd ../../..
+RUN cd lib/PG/htdocs && npm install && cd ../../.. && npm install
 
 EXPOSE 3000
 

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -1,0 +1,49 @@
+version: '3.5'
+
+services:
+  renderer:
+    image: renderer:latest
+    container_name: standalone-renderer
+
+    build:
+      # For use/building when docker-compose.yml is in the container directory
+      context: .
+      # For use/building when docker-compose.yml is OUTSIDE the container directory.
+      #context: /Path_To/container/
+
+      # If you would like a 1 stage build process comment out the next line, and just run "docker-compose build".
+      dockerfile: DockerfileStage2
+
+      # For the 2 stage build process:
+      # Stage 1 - base image with OS + CPAN packages
+      #      docker build --no-cache --tag renderer-base:latest -f container/DockerfileStage1 .
+      #   You can add something like
+      #       --build-arg ADDITIONAL_BASE_IMAGE_PACKAGES="vim-tiny"
+      #   to add additional packages to the base image
+      # Stage 2 - add the renderer to the base image
+      #      docker-compose build --no-cache
+
+    volumes:
+
+      # Local render_app.conf if needed:
+      #- "./render_app.conf:/usr/app/render_app.conf"
+
+      # OPL - from standard location
+      - "../volumes/webwork-open-problem-library:/usr/app/webwork-open-problem-library"
+
+      # Private problem directories - from standard location
+      #- "./volumes/private:/usr/app/private"
+
+    #hostname: myhost.mydomain.edu
+
+    ports:
+      - "3000:3000"
+
+    environment:
+      MOJO_MODE: development
+
+      # The system timezone for the container can be set using
+      #SYSTEM_TIMEZONE: zone/city
+      # where zone/city must be a valid setting.
+      # "/usr/bin/timedatectl list-timezones" on an Ubuntu system with
+      # that tool installed will find valid values.


### PR DESCRIPTION
Intended to make the Docker build work, and to split it into a 2 stage build, so the underlying OS packages and CPAN installs need not be redone for each rebuild of the main image.

Changes were made to use `docker-compose` which makes it easier to have persistent settings for additional mounts, etc. rather than putting everything into the `docker run` command.

It also updates the build instructions in `README.md` and points those to use the openwebwork repository and not the drdrew42 repository.

Note: `.git` was removed from `.dockerignore` as otherwise the `npm install` inside `lib/PG/htdocs` is failing.
  - 2 stage build process
  - changes needed after the PG-2.17 update and the changes to how codemirror is included.
  - update build instructions and other things in README.md

This replaces https://github.com/openwebwork/renderer/pull/4 and is built on top of the current develop branch.