### PR TITLE
Starting a cleanup push

### DIFF
--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -107,20 +107,20 @@ sub startup {
 	$r->any('/pg_files/CAPA_Graphics/*static')->to('StaticFiles#CAPA_graphics_file');
 	$r->any('/pg_files/tmp/*static')->to('StaticFiles#temp_file');
 	$r->any('/pg_files/*static')->to('StaticFiles#pg_file');
-
-	# any other requests fall through
-	$r->any('/*fail' => sub {
-		my $c = shift;
-		my $report = $c->stash('fail')."\nCOOKIE:";
-		for my $cookie (@{$c->req->cookies}) {
-			$report .= "\n".$cookie->to_string;
-		}
-		$report .= "\nFORM DATA:";
-		foreach my $k (@{$c->req->params->names}) {
-			$report .= "\n$k = ".join ', ', @{$c->req->params->every_param($k)};
-		}
-		$c->log->fatal($report);
-		$c->rendered(404)});
+    $r->any('/*fail')->to('StaticFiles#public_file');
+	# # any other requests fall through
+	# $r->any('/*fail' => sub {
+	# 	my $c = shift;
+	# 	my $report = $c->stash('fail')."\nCOOKIE:";
+	# 	for my $cookie (@{$c->req->cookies}) {
+	# 		$report .= "\n".$cookie->to_string;
+	# 	}
+	# 	$report .= "\nFORM DATA:";
+	# 	foreach my $k (@{$c->req->params->names}) {
+	# 		$report .= "\n$k = ".join ', ', @{$c->req->params->every_param($k)};
+	# 	}
+	# 	$c->log->fatal($report);
+	# 	$c->rendered(404)});
 }
 
 1;

--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -96,6 +96,8 @@ sub startup {
 		$r->any('/render-api/cat')->to('IO#catalog');
 		$r->any('/render-api/find')->to('IO#search');
 		$r->post('/render-api/upload')->to('IO#upload');
+		$r->delete('/render-api/remove')->to('IO#remove');
+		$r->post('/render-api/clone')->to('IO#clone');
 		$r->post('/render-api/sma')->to('IO#findNewVersion');
 		$r->post('/render-api/unique')->to('IO#findUniqueSeeds');
 		$r->post('/render-api/tags')->to('IO#setTags');

--- a/lib/RenderApp/Controller/FormatRenderedProblem.pm
+++ b/lib/RenderApp/Controller/FormatRenderedProblem.pm
@@ -102,7 +102,7 @@ sub formatRenderedProblem {
 	my $problemHeadText       = $rh_result->{header_text}//'';  ##head_text vs header_text
 	my $problemPostHeaderText = $rh_result->{post_header_text}//'';
 	my $rh_answers            = $rh_result->{answers}//{};
-	my $answerOrder           = $rh_result->{flags}->{ANSWER_ENTRY_ORDER}; #[sort keys %{ $rh_result->{answers} }];
+	my $answerOrder           = $rh_result->{flags}->{ANSWER_ENTRY_ORDER}//[]; #[sort keys %{ $rh_result->{answers} }];
 	my $encoded_source        = $self->encoded_source//'';
 	my $sourceFilePath        = $self->{sourceFilePath}//'';
 	my $problemSourceURL      = $self->{inputs_ref}->{problemSourceURL};
@@ -166,9 +166,9 @@ sub formatRenderedProblem {
 	my $sessionJWT         = $self->{return_object}{sessionJWT} // '';
 
 	my $previewMode     = defined( $self->{inputs_ref}{previewAnswers} )     || 0;
-	my $checkMode       = defined( $self->{inputs_ref}{checkAnswers} )       || 0;
-	my $submitMode      = defined( $self->{inputs_ref}{submitAnswers} )      || 0;
+	# showCorrectMode needs more security -- ww2 uses want/can/will
 	my $showCorrectMode = defined( $self->{inputs_ref}{showCorrectAnswers} ) || 0;
+	my $submitMode = defined($self->{inputs_ref}{submitAnswers}) || $self->{inputs_ref}{answersSubmitted} || 0;
 
 	# problemUUID can be added to the request as a parameter.  It adds a prefix
 	# to the identifier used by the  format so that several different problems
@@ -180,6 +180,8 @@ sub formatRenderedProblem {
 		// $rh_result->{flags}{showPartialCorrectAnswers};
 	my $showSummary   = $self->{inputs_ref}{showSummary} // 1;    #default to show summary for the moment
 	my $formLanguage  = $self->{inputs_ref}{language}    // 'en';
+	my $showTable = $self->{inputs_ref}{hideAttemptsTable} ? 0 : 1;
+	my $showMessages = $self->{inputs_ref}{hideMessages} ? 0 : 1;
 	my $scoreSummary  = '';
 
 	my $COURSE_LANG_AND_DIR = get_lang_and_dir($formLanguage);
@@ -191,24 +193,27 @@ sub formatRenderedProblem {
 	my $PROBLEM_LANG_AND_DIR = join(" ", map { qq{$_="$PROBLEM_LANG_AND_DIR{$_}"} } keys %PROBLEM_LANG_AND_DIR);
 	my $mt = WeBWorK::Localize::getLangHandle($self->{inputs_ref}{language} // 'en');
 
-	my $tbl = WeBWorK::Utils::AttemptsTable->new(
-		$rh_answers,
-		answersSubmitted       => $self->{inputs_ref}{answersSubmitted}//0,
-		answerOrder            => $answerOrder//[],
-		displayMode            => $self->{inputs_ref}{displayMode},
-		showAnswerNumbers      => 0,
-		showAttemptAnswers     => 0,
-		showAttemptPreviews    => ($previewMode or $submitMode or $showCorrectMode),
-		showAttemptResults     => ($submitMode and $showPartialCorrectAnswers),
-		showCorrectAnswers     => ($showCorrectMode),
-		showMessages           => ($previewMode or $submitMode or $showCorrectMode),
-		showSummary            => ( ($showSummary and ($submitMode or $showCorrectMode) )//0 )?1:0,
-		maketext               => WeBWorK::Localize::getLoc($formLanguage//'en'),
-		summary                => $problemResult->{summary} //'', # can be set by problem grader???
-	);
+	my $answerTemplate = '';
+	if ($submitMode && $showTable) {
+		my $tbl = WeBWorK::Utils::AttemptsTable->new(
+			$rh_answers,
+			answersSubmitted    => 1,
+			answerOrder         => $answerOrder,
+			displayMode         => $displayMode,
+			showAnswerNumbers   => 0,
+			showAttemptAnswers  => 0,
+			showAttemptPreviews => 1,
+			showAttemptResults  => $showPartialCorrectAnswers,
+			showCorrectAnswers  => $showCorrectMode,
+			showMessages        => $showMessages,
+			showSummary         => $showSummary,
+			maketext            => WeBWorK::Localize::getLoc($formLanguage),
+			summary             => $problemResult->{summary} // '',                     # can be set by problem grader???
+		);
 
-	my $answerTemplate = $tbl->answerTemplate;
-	$tbl->imgGen->render(body_text => \$answerTemplate) if $tbl->displayMode eq 'images';
+		$answerTemplate = $tbl->answerTemplate;
+		$tbl->imgGen->render(body_text => \$answerTemplate) if $tbl->displayMode eq 'images';
+	}
 
 	# warn "imgGen is ", $tbl->imgGen;
 	#warn "answerOrder ", $tbl->answerOrder;

--- a/lib/RenderApp/Controller/FormatRenderedProblem.pm
+++ b/lib/RenderApp/Controller/FormatRenderedProblem.pm
@@ -255,7 +255,7 @@ sub formatRenderedProblem {
 			} else {
 				my $url = getAssetURL($self->{inputs_ref}{language} // 'en', $_->{file});
 				push @{ $rh_result->{js} }, $SITE_URL.$url;
-				$extra_js_files .= CGI::script({ src => $url, %attributes }, '');
+				$extra_js_files .= CGI::script({ src => $SITE_URL.$url, %attributes }, '');
 			}
 		}
 	}
@@ -278,7 +278,7 @@ sub formatRenderedProblem {
 		} else {
 			my $url = getAssetURL($self->{inputs_ref}{language} // 'en', $_->{file});
 			push @{ $rh_result->{css} }, $SITE_URL.$url;
-			$extra_css_files .= CGI::Link({ href => $url, rel => 'stylesheet' });
+			$extra_css_files .= CGI::Link({ href => $SITE_URL.$url, rel => 'stylesheet' });
 		}
 	}
 

--- a/lib/RenderApp/Controller/IO.pm
+++ b/lib/RenderApp/Controller/IO.pm
@@ -254,13 +254,12 @@ sub depthSearch_p {
             my $wanted = sub {
                 # measure depth relative to root_path
                 ( my $rel = $File::Find::name ) =~ s!^\Q$root_path\E/?!!;
+                return unless $rel;
                 my $path = $File::Find::name;
                 $File::Find::prune = 1
                   if File::Spec::Functions::splitdir($rel) >= $depth;
                 $path = $path . '/' if -d $File::Find::name;
-                # only report .pg files and directories
-                $all{$rel} = $path
-                  if ( $rel =~ /\S/ && ( $path =~ m!.+/$! || $path =~ m!.+\.pg$! ) );
+                $all{$rel} = $path;
             };
             File::Find::find { wanted => $wanted, no_chdir => 1 }, $root_path;
             return \%all, 200;

--- a/lib/RenderApp/Controller/IO.pm
+++ b/lib/RenderApp/Controller/IO.pm
@@ -118,6 +118,91 @@ sub upload {
     return $c->render( text => 'File successfully uploaded', status => 200 );
 }
 
+sub remove {
+  my $c = shift;
+  my $required = [];
+  push @$required,
+    {
+      field     => 'removeFilePath',
+      checkType => 'like',
+      check     => $regex->{privateOnly},
+    };
+  my $validatedInput = $c->validateRequest( { required => $required } );
+  return unless $validatedInput;
+
+  my $file_path = $validatedInput->{removeFilePath};
+  my $file = Mojo::File->new($file_path);
+
+  return $c->render( text => 'Path does not exist', status => 404 )
+    unless (-e $file);
+
+  if (-d $file) {
+    return $c->render( text => 'Directory is not empty', status => 400 )
+      unless ($file->list({ dir => 1 })->size == 0);
+
+    $file->remove_tree;
+  } else {
+    $file->remove;
+  }
+
+  return $c->render( text => 'Path deleted' );
+}
+
+sub clone {
+  my $c = shift;
+  my $required = [];
+  push @$required,
+    {
+      field     => 'sourceFilePath',
+      checkType => 'like',
+      check     => $regex->{privateOnly},
+    };
+  push @$required,
+    {
+      field     => 'targetFilePath',
+      checkType => 'like',
+      check     => $regex->{privateOnly},
+    };
+  my $validatedInput = $c->validateRequest( { required => $required } );
+  return unless $validatedInput;
+
+  my $source_path = $validatedInput->{sourceFilePath};
+  my $source_file = Mojo::File->new($source_path);
+  my $target_path = $validatedInput->{targetFilePath};
+  my $target_file = Mojo::File->new($target_path);
+  
+  return $c->render( text => 'source does not exist', status => 404 )
+    unless (-e $source_file);
+
+  return $c->render( text => 'target already exists', status => 400 )
+    if (-e $target_file);
+
+  # allow cloning of directories - problems with static assets
+  # no recursing through directories!
+  if (-d $source_file) {
+    return $c->render( text => 'source does not contain clone-able files', status => 400)
+      if ($source_file->list->size == 0);
+
+    return $c->render( text => 'target must also be a directory', status => 400)
+      unless ($target_path =~ m!.*/$!);
+    
+    $target_file->make_path;
+    for ($source_file->list->each) {
+      $_->copy_to($target_path . $_->basename);
+    }
+  } else {
+    return $c->render( text => 'you may not create new directories with this method', status => 400)
+      unless (-e $target_file->dirname);
+
+    return($c->render( text => 'file extensions do not match'))
+      unless ($source_file->extname eq $target_file->extname);
+
+    $source_file->copy_to($target_file);
+  }
+
+  return $c->render( text => 'clone successful' );
+}
+
 async sub catalog {
     my $c = shift;
     my $required = [];

--- a/lib/RenderApp/Controller/Render.pm
+++ b/lib/RenderApp/Controller/Render.pm
@@ -91,7 +91,7 @@ sub fetchRemoteSource_p {
     then(
       sub {
           my $tx = shift;
-          return encode_base64($tx->result->body);
+          return $tx->result->body;
       })->
     catch(
       sub {

--- a/lib/RenderApp/Controller/RenderProblem.pm
+++ b/lib/RenderApp/Controller/RenderProblem.pm
@@ -427,7 +427,7 @@ sub get_current_process_memory {
 sub generateJWTs {
     my $pg = shift;
     my $inputs_ref = shift;
-    my $sessionHash = {'answersSubmitted' => 1, 'iss' =>$ENV{SITE_HOST}};
+    my $sessionHash = {'answersSubmitted' => 1, 'iss' =>$ENV{SITE_HOST}, problemJWT => $inputs_ref->{problemJWT}};
     my $scoreHash = {};
 
     # if no problemJWT exists, then why bother?

--- a/lib/RenderApp/Controller/StaticFiles.pm
+++ b/lib/RenderApp/Controller/StaticFiles.pm
@@ -28,4 +28,8 @@ sub pg_file ($c) {
 	$c->reply_with_file_if_readable(path($ENV{PG_ROOT}, 'htdocs', $c->stash('static')));
 }
 
+sub public_file($c) {
+    $c->reply_with_file_if_readable($c->app->home->child('public', $c->stash('fail')));
+}
+
 1;

--- a/lib/WebworkClient/classic_format.pl
+++ b/lib/WebworkClient/classic_format.pl
@@ -42,14 +42,7 @@ $problemPostHeaderText
           </div>
           $scoreSummary
 
-          <input type="hidden" name="answersSubmitted" value="1">
-          <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
-          <input type="hidden" name="problemSourceURL" value = "$problemSourceURL">
-          <input type="hidden" name="problemSource" value="$encoded_source">
-          <input type="hidden" name="problemSeed" value = "$problemSeed">
-		  <input type="hidden" name="outputFormat" value="classic">
-          <input type="hidden" name="language" value="$formLanguage">
-          <input type="hidden" name="showSummary" value="$showSummary">
+          <input type="hidden" name="sessionJWT" value="$sessionJWT">
           <p>
             <input type="submit" name="previewAnswers" class="btn btn-primary" value="$STRING_Preview" />
             <input type="submit" name="submitAnswers" class="btn btn-primary" value="$STRING_Submit"/>

--- a/lib/WebworkClient/jwe_secure_format.pl
+++ b/lib/WebworkClient/jwe_secure_format.pl
@@ -90,6 +90,12 @@ $problemPostHeaderText
         });
         event.source.postMessage('updated templates', event.origin);
       }
+
+      if (message.hasOwnProperty('showSolutions')) {
+        const elements = Array.from(window.document.querySelectorAll('.knowl[data-type="solution"]'));
+        const solutions = elements.map(el => el.dataset.knowlContents);
+        event.source.postMessage(JSON.stringify({solutions: solutions}), event.origin);
+      }
     });
   </script>
 </body>

--- a/lib/WebworkClient/jwe_secure_format.pl
+++ b/lib/WebworkClient/jwe_secure_format.pl
@@ -65,15 +65,22 @@ $problemPostHeaderText
       catch (e) {
         return;
       }
+      
       if (message.hasOwnProperty('styles')) {
         message.styles.forEach((incoming) => {
           const elements = window.document.querySelectorAll(incoming.selector);
-          elements.forEach(el => el.style.cssText += incoming.style);
+          elements.forEach(el => el.style.cssText = incoming.style);
         });
-      } else {
-        return;
+        event.source.postMessage('css styles updated', event.origin);
       }
-      event.source.postMessage('css updated', event.origin);
+
+      if (message.hasOwnProperty('classes')) {
+        message.classes.forEach((incoming) => {
+          const elements = window.document.querySelectorAll(incoming.selector);
+          elements.forEach(el => el.className = incoming.class);
+        });
+        event.source.postMessage('css classes updated', event.origin);
+      }
     });
   </script>
 </body>

--- a/lib/WebworkClient/jwe_secure_format.pl
+++ b/lib/WebworkClient/jwe_secure_format.pl
@@ -31,7 +31,7 @@ $problemPostHeaderText
 
 <title>WeBWorK using host: $SITE_URL</title>
 </head>
-<body>
+<body onLoad="window.parent.postMessage('loaded', '*')" >
   <div class="container-fluid">
     <div class="row">
       <div class="col-12 problem">
@@ -56,6 +56,25 @@ $problemPostHeaderText
       console.log("response message ", JSON.parse('JWTanswerURLstatus'));
       window.parent.postMessage('JWTanswerURLstatus', '*');
     }
+
+    window.addEventListener('message', event => {
+      let message;
+      try {
+        message = JSON.parse(event.data);
+      } 
+      catch (e) {
+        return;
+      }
+      if (message.hasOwnProperty('styles')) {
+        message.styles.forEach((incoming) => {
+          const elements = window.document.querySelectorAll(incoming.selector);
+          elements.forEach(el => el.style.cssText += incoming.style);
+        });
+      } else {
+        return;
+      }
+      event.source.postMessage('css updated', event.origin);
+    });
   </script>
 </body>
 </html>

--- a/lib/WebworkClient/jwe_secure_format.pl
+++ b/lib/WebworkClient/jwe_secure_format.pl
@@ -66,20 +66,29 @@ $problemPostHeaderText
         return;
       }
       
-      if (message.hasOwnProperty('styles')) {
-        message.styles.forEach((incoming) => {
-          const elements = window.document.querySelectorAll(incoming.selector);
-          elements.forEach(el => el.style.cssText = incoming.style);
+      if (message.hasOwnProperty('elements')) {
+        message.elements.forEach((incoming) => {
+          let elements;
+          if (incoming.hasOwnProperty('selector')) {
+            elements = window.document.querySelectorAll(incoming.selector);
+            if (incoming.hasOwnProperty('style')) {
+              elements.forEach(el => {el.style.cssText = incoming.style});
+            }
+            if (incoming.hasOwnProperty('class')) {
+              elements.forEach(el => {el.className = incoming.class});
+            }
+          }
         });
-        event.source.postMessage('css styles updated', event.origin);
+        event.source.postMessage('updated elements', event.origin);
       }
 
-      if (message.hasOwnProperty('classes')) {
-        message.classes.forEach((incoming) => {
-          const elements = window.document.querySelectorAll(incoming.selector);
-          elements.forEach(el => el.className = incoming.class);
+      if (message.hasOwnProperty('templates')) {
+        message.templates.forEach((cssString) => {
+          const element = document.createElement('style');
+          element.innerText = cssString;
+          document.head.insertAdjacentElement('beforeend', element);
         });
-        event.source.postMessage('css classes updated', event.origin);
+        event.source.postMessage('updated templates', event.origin);
       }
     });
   </script>

--- a/lib/WebworkClient/nosubmit_format.pl
+++ b/lib/WebworkClient/nosubmit_format.pl
@@ -39,12 +39,7 @@ $problemPostHeaderText
           </div>
           $scoreSummary
 
-          <input type="hidden" name="answersSubmitted" value="1">
-          <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
-          <input type="hidden" name="problemSource" value="$encoded_source">
-          <input type="hidden" name="problemSeed" value = "$problemSeed">
-          <input type="hidden" name="language" value="$formLanguage">
-          <input type="hidden" name="showSummary" value="$showSummary">
+          <input type="hidden" name="sessionJWT" value="$sessionJWT">
         </form>
       </div>
     </div>

--- a/lib/WebworkClient/practice_format.pl
+++ b/lib/WebworkClient/practice_format.pl
@@ -42,13 +42,7 @@ $problemPostHeaderText
           </div>
           $scoreSummary
 
-          <input type="hidden" name="answersSubmitted" value="1">
-          <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
-          <input type="hidden" name="problemSource" value="$encoded_source">
-          <input type="hidden" name="problemSeed" value = "$problemSeed">
-		  <input type="hidden" name="outputFormat" value="$format_name">
-          <input type="hidden" name="language" value="$formLanguage">
-          <input type="hidden" name="showSummary" value="$showSummary">
+          <input type="hidden" name="sessionJWT" value="$sessionJWT">
           <p>
             <input type="submit" name="submitAnswers" class="btn btn-primary" value="Check Answers"/>
             <input type="submit" name="showCorrectAnswers" class="btn btn-primary" value="$STRING_ShowCorrect"/>

--- a/lib/WebworkClient/simple_format.pl
+++ b/lib/WebworkClient/simple_format.pl
@@ -42,14 +42,7 @@ $problemPostHeaderText
           </div>
           $scoreSummary
 
-          <input type="hidden" name="answersSubmitted" value="1">
-          <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
-          <input type="hidden" name="problemSourceURL" value = "$problemSourceURL">
-          <input type="hidden" name="problemSource" value="$encoded_source">
-          <input type="hidden" name="problemSeed" value = "$problemSeed">
-          <input type="hidden" name="outputFormat" value="simple">
-		  <input type="hidden" name="language" value="$formLanguage">
-          <input type="hidden" name="showSummary" value="$showSummary">
+          <input type="hidden" name="sessionJWT" value="$sessionJWT">
           <p>
             <input type="submit" name="previewAnswers" class="btn btn-primary" value="$STRING_Preview" />
             <input type="submit" name="submitAnswers" class="btn btn-primary" value="$STRING_Submit"/>

--- a/lib/WebworkClient/single_format.pl
+++ b/lib/WebworkClient/single_format.pl
@@ -41,14 +41,7 @@ $problemPostHeaderText
           </div>
           $scoreSummary
 
-          <input type="hidden" name="answersSubmitted" value="1">
-          <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
-          <input type="hidden" name="problemSourceURL" value = "$problemSourceURL">
-          <input type="hidden" name="problemSource" value="$encoded_source">
-          <input type="hidden" name="problemSeed" value = "$problemSeed">
-		  <input type="hidden" name="outputFormat" value="$format_name">
-          <input type="hidden" name="language" value="$formLanguage">
-          <input type="hidden" name="showSummary" value="$showSummary">
+          <input type="hidden" name="sessionJWT" value="$sessionJWT">
           <p>
             <input type="submit" name="submitAnswers" class="btn btn-primary" value="$STRING_Submit"/>
           </p>

--- a/lib/WebworkClient/standard_format.pl
+++ b/lib/WebworkClient/standard_format.pl
@@ -41,22 +41,7 @@ $answerTemplate
   </div>
   $scoreSummary
 
-  <input type="hidden" name="answersSubmitted" value="1">
-  <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
-  <input type="hidden" name="problemSourceURL" value = "$problemSourceURL">
-  <input type="hidden" name="problemSource" value="$encoded_source">
-  <input type="hidden" name="problemSeed" value="$problemSeed">
-  <input type="hidden" name="problemUUID" value="$problemUUID">
-  <input type="hidden" name="psvn" value="$psvn">
-  <input type="hidden" name="pathToProblemFile" value="$fileName">
-  <input type="hidden" name=courseName value="$courseID">
-  <input type="hidden" name=courseID value="$courseID">
-  <input type="hidden" name="userID" value="$userID">
-  <input type="hidden" name="course_password" value="$course_password">
-  <input type="hidden" name="displayMode" value="$displayMode">
-  <input type="hidden" name="outputFormat" value="standard">
-  <input type="hidden" name="language" value="$formLanguage">
-  <input type="hidden" name="showSummary" value="$showSummary">
+  <input type="hidden" name="sessionJWT" value="$sessionJWT">
 
   <p>
     Show:&nbsp;&nbsp;

--- a/lib/WebworkClient/standard_format.pl
+++ b/lib/WebworkClient/standard_format.pl
@@ -68,7 +68,7 @@ $answerTemplate
 
     <input type="submit" name="previewAnswers" class="btn btn-primary" value="$STRING_Preview" />
     <input type="submit" name="submitAnswers" class="btn btn-primary" value="$STRING_Submit"/>
-    <input type="submit" name="showCorrectAns" class="btn btn-primary" value="$STRING_ShowCorrect"/>
+    <input type="submit" name="showCorrectAnswers" class="btn btn-primary" value="$STRING_ShowCorrect"/>
   </p>
 </form>
 <HR>

--- a/lib/WebworkClient/static_format.pl
+++ b/lib/WebworkClient/static_format.pl
@@ -39,14 +39,7 @@ $problemPostHeaderText
           </div>
           $scoreSummary
 
-          <input type="hidden" name="answersSubmitted" value="1">
-          <input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
-          <input type="hidden" name="problemSourceURL" value = "$problemSourceURL">
-          <input type="hidden" name="problemSource" value="$encoded_source">
-          <input type="hidden" name="problemSeed" value = "$problemSeed">
-		  <input type="hidden" name="outputFormat" value="static">
-          <input type="hidden" name="language" value="$formLanguage">
-          <input type="hidden" name="showSummary" value="$showSummary">
+          <input type="hidden" name="sessionJWT" value="$sessionJWT">
         </form>
       </div>
     </div>

--- a/lib/WebworkClient/ww3_format.pl
+++ b/lib/WebworkClient/ww3_format.pl
@@ -9,13 +9,7 @@ $problemHeadText
 		$problemText
 	</div>
 
-	<input type="hidden" name="answersSubmitted" value="1">
-	<input type="hidden" name="sourceFilePath" value = "$sourceFilePath">
-	<input type="hidden" name="problemSourceURL" value = "$problemSourceURL">
-	<input type="hidden" name="problemSource" value="$encoded_source">
-	<input type="hidden" name="problemSeed" value = "$problemSeed">
-	<input type="hidden" name="language" value="$formLanguage">
-	<input type="hidden" name="showSummary" value="$showSummary">
+	<input type="hidden" name="sessionJWT" value="$sessionJWT">
 </form>
 ENDPROBLEMTEMPLATE
 };

--- a/templates/exception.html.ep
+++ b/templates/exception.html.ep
@@ -1,5 +1,5 @@
-%= stylesheet $ENV{SITE_HOST} . '/typing-sim.css'
-%= stylesheet $ENV{SITE_HOST} . '/crt-display.css'
+%= stylesheet $ENV{baseURL} . '/typing-sim.css'
+%= stylesheet $ENV{baseURL} . '/crt-display.css'
 %= javascript begin
 window.onload = function() {
     var i = 0;


### PR DESCRIPTION
This PR expands on #11, which should be merged first. 

## Changes

### Absolute URLs

Stop relying on base href and instead use absolute URLs in templates.

### problemJWT
Convert all requests to use JWTs.

Problem render requests are pre-processed into a problemJWT, capturing the original request parameters. The problemJWT is then stashed in the sessionJWT (which also keeps track of the most recently submitted answers), ensuring consistent settings throughout multiple interactions.

In production, this means that a stored sessionJWT is capable of re-rendering any submission. If the LMS needs to change any of the problem parameters, a new problemJWT may be submitted along with the stored sessionJWT in order to override the existing parameters in the sessionJWT. Further interaction with the problem will use the new problemJWT in place of the old one (so the new problemJWT must be complete, rather than considered as a patch to the existing problemJWT).

### showCorrectAnswers

Any parameter set by the problemJWT is not override-able. If a user should be blocked from `showCorrectAnswers`, it must be set to false in the initial problemJWT. However, this then blocks the user from ever being able to `showCorrectAnswers` without replacing the problemJWT. (This may be the preferred solution.)

If however, `showCorrectAnswers` is not secured: whenever this parameter is included in a request, it will be stored in the sessionJWT where it cannot be removed. Rendering a problem with `showCorrectAnswers` will further lock the JWT into rendering in static format, preventing any further interaction. 

@drgrice1 - this is the purpose for having a static option either with mqeditor, or otherwise loadable from the static template -- if an LMS implements their own submit buttons, this implementation will not suffice. This precaution should probably be expanded upon.

### base64 source

`problemSource` is no longer required to be base64 encoded.

AFAIK, there's no longer any need for base64 encoding, but for backwards compatibility, it is recognized and supported when a request provides `problemSource`.

### RenderProblem cleanup

Cleanup and streamline the RenderProblem.pm file.

Minor changes to functionality:
- Preparation for restructuring answerJWT, which currently sends the entire `pg->{answers}` hash.
- SessionJWTs will cease updating attempt counts once a correct attempt has been scored.

## TODO

- [ ] Convert FormatRenderedProblem to follow the ww2 approach of using Mojo::Templates.
- [ ] Expand on `showCorrectAnswers` precautions
- [ ] LINTING
- [ ] ??? 

