### PR TITLE
Remove some setup of routes that are done twice.

### DIFF
--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -133,21 +133,6 @@ sub startup {
 	$r->any('/render-api')->to('render#problem');
 	$r->any('/render-ptx')->to('render#render_ptx');
 	$r->any('/health' => sub { shift->rendered(200) });
-	$r->any('/health' => sub {shift->rendered(200)});
-	if ($self->mode eq 'development' || $self->config('FULL_APP_INSECURE')) {
-		$r->any('')->to('pages#twocolumn');
-		$r->any('/')->to('pages#twocolumn');
-		$r->any('/opl')->to('pages#oplUI');
-		$r->any('/die' => sub {die "what did you expect, flowers?"});
-		$r->any('/timeout' => sub {
-			my $c = shift;
-			my $tx = $c->render_later->tx;
-			Mojo::IOLoop->timer(2 => sub {
-				$tx = $tx; # prevent $tx from going out of scope
-				$c->rendered(200);
-			});
-		});
-  }
 
 	# Enable problem editor & OPL browser -- NOT recommended for production environment!
 	supplementalRoutes($r) if ($self->mode eq 'development' || $self->config('FULL_APP_INSECURE'));
@@ -157,7 +142,6 @@ sub startup {
 	$r->any('/pg_files/tmp/*static')->to('StaticFiles#temp_file');
 	$r->any('/pg_files/*static')->to('StaticFiles#pg_file');
 	$r->any('/*static')->to('StaticFiles#public_file');
-
 }
 
 sub supplementalRoutes {


### PR DESCRIPTION
The removed code is all done again in the `supplementalRoutes` method, and so is not needed.