### PR TITLE
Remove the STATIC_EXPIRES option.

### DIFF
--- a/lib/Renderer.pm
+++ b/lib/Renderer.pm
@@ -84,35 +84,6 @@ sub startup {
 		$self->helper(logAttempt => sub { shift; $resultsLog->info(@_); });
 	}
 
-	# Add Cache-Control and Expires headers to static content from webwork2_files
-	if (my $STATIC_EXPIRES = $self->config('STATIC_EXPIRES')) {
-		$STATIC_EXPIRES = int($STATIC_EXPIRES);
-		my $cache_control_setting = "max-age=$STATIC_EXPIRES";
-		my $no_cache_setting      = 'max-age=1, no-cache';
-		$self->hook(
-			after_dispatch => sub {
-				my $c = shift;
-
-				# Only process if file requested is under webwork2_files
-				return unless ($c->req->url->path =~ '^/webwork2_files/');
-
-				if ($c->req->url->path =~ '/tmp/renderer') {
-					# Treat problem generated files as already expired.
-					# They should not be cached.
-					$c->res->headers->cache_control($no_cache_setting);
-					$c->res->headers->header(
-						Expires => Mojo::Date->new(time - 86400)    # expired 24 hours ago
-					);
-				} else {
-					# Standard "static" files.
-					# They can be cached
-					$c->res->headers->cache_control($cache_control_setting);
-					$c->res->headers->header(Expires => Mojo::Date->new(time + $STATIC_EXPIRES));
-				}
-			}
-		);
-	}
-
 	# Models
 	$self->helper(newProblem => sub { shift; Renderer::Model::Problem->new(@_) });
 

--- a/renderer.conf.dist
+++ b/renderer.conf.dist
@@ -6,7 +6,6 @@
   webworkJWTsecret => 'private',
   SITE_HOST => 'http://localhost:3000',
   CORS_ORIGIN => '*',
-  STATIC_EXPIRES => 86400,
   STRICT_JWT => 0,
   FULL_APP_INSECURE => 0,
   INTERACTION_LOG => 0,


### PR DESCRIPTION
The option is set up to set an expiration for static assets served from the `webwork2_files` route.  However, there is no such route anymore for the renderer, and so the option currently does nothing.  This could be adapted to work for the other files in public, but there is not point in that.  The static assets used in production are either local assets that are minimized and served with a hash in the file name, or are third party assets and a version parameter is appended as a query parameter. As such, when files change the browser will get the new versions.