### PR TITLE
Ensure outputformat is accepted as an alternative to outputFormat.

### DIFF
--- a/lib/Renderer/Controller/Render.pm
+++ b/lib/Renderer/Controller/Render.pm
@@ -10,6 +10,7 @@ use WeBWorK::PreTeXt;
 sub parseRequest {
 	my $c      = shift;
 	my %params = %{ $c->req->params->to_hash };
+	$params{outputFormat} ||= $params{outputformat} || 'default';
 
 	my $originIP = $c->req->headers->header('X-Forwarded-For')
 		// '' =~ s!^\s*(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*$!$1!r;

--- a/lib/WeBWorK/FormatRenderedProblem.pm
+++ b/lib/WeBWorK/FormatRenderedProblem.pm
@@ -87,7 +87,7 @@ sub formatRenderedProblem {
 	);
 
 	# Get the requested format. (outputFormat or outputformat)
-	my $formatName = $inputs_ref->{outputFormat} || 'default';
+	my $formatName = $inputs_ref->{outputFormat} || $inputs_ref->{outputformat} || 'default';
 
 	# Add JS files requested by problems via ADD_JS_FILE() in the PG file.
 	my @extra_js_files;


### PR DESCRIPTION
WeBWorK RPC uses `outputformat`, so allow the renderer to accept `outputformat` as an alternative to `outputFormat` if defined.

(oops, added a branch here instead of my fork)